### PR TITLE
fix(dashboard): Ensure company info is always fetched on load

### DIFF
--- a/src/app/api/company-info/route.ts
+++ b/src/app/api/company-info/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { getCompanyInfo } from '@/lib/queries';
+
+export async function GET() {
+  try {
+    const companyInfo = await getCompanyInfo();
+    if (!companyInfo) {
+      return NextResponse.json({ message: 'Company information not found' }, { status: 404 });
+    }
+    return NextResponse.json(companyInfo);
+  } catch (error) {
+    console.error('Failed to fetch company info:', error);
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/hooks/use-store.ts
+++ b/src/hooks/use-store.ts
@@ -77,12 +77,6 @@ export const StoreProvider = ({ children }: { children: ReactNode }) => {
     const initializeApp = async () => {
       try {
         const dataPromise = (async () => {
-          // Do not re-fetch if data is already in localStorage.
-          // This is a temporary measure; proper state management would use a library like SWR or React Query.
-          if (window.localStorage.getItem('projects')) {
-            return;
-          }
-
           const [
             projectsRes,
             tasksRes,


### PR DESCRIPTION
The company information was not being displayed on the dashboard because of a faulty caching mechanism in the `useStore` hook. An early return statement would prevent all data, including the company info, from being fetched if any project data was found in `localStorage`.

This commit addresses the issue by:
1. Removing the conditional check in `useStore`, ensuring that all necessary data, including `company_info`, is fetched every time the application loads.
2. Adding the missing API route at `/api/company-info/route.ts` to handle requests for the company information.