### PR TITLE
fix: Resolve login redirect issue and race condition

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -29,32 +29,35 @@ import { CompanyHeaderInfo } from './company-header-info';
 import Image from 'next/image';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion';
 import { ThemeSwitcher } from '../theme-switcher';
+import { useSession } from 'next-auth/react';
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
-  const { isLoaded, currentUser, getRole, logout, companyInfo, workspaces } = useStore();
+  const { status } = useSession();
+  const { isLoaded, currentUser, getRole, companyInfo, workspaces } = useStore();
 
   useEffect(() => {
-    if (isLoaded && !currentUser) {
+    if (status === 'unauthenticated') {
       router.push('/login');
     }
-  }, [isLoaded, currentUser, router]);
-
-  const handleLogout = () => {
-    logout();
-    router.push('/login');
-  };
+  }, [status, router]);
   
-  if (!isLoaded || !currentUser) {
+  // Show a loading skeleton while the session is loading or the store data is not yet ready.
+  // We also wait for currentUser to be populated to prevent a flash of the loading screen
+  // between the session being ready and the user object being found in the store.
+  if (status === 'loading' || !isLoaded || !currentUser) {
     return (
-        <div className="flex items-center justify-center min-h-screen">
-            <div className="p-4 space-y-4">
-                <Skeleton className="h-12 w-12 rounded-full" />
-                <Skeleton className="h-4 w-[250px]" />
-                <Skeleton className="h-4 w-[200px]" />
-            </div>
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <div className="p-4 space-y-4 text-center">
+          <div className="flex justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" className="h-12 w-12 fill-current animate-pulse">
+                <path d="M228.4,89.35l-96-64a8,8,0,0,0-8.8,0l-96,64A8,8,0,0,0,24,96V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V96A8,8,0,0,0,228.4,89.35ZM128,42.22,203.1,88,128,133.78,52.9,88ZM40,107.51l88,58.67,88-58.67V200H40Z"/>
+            </svg>
+          </div>
+          <p className="text-muted-foreground">Carregando...</p>
         </div>
+      </div>
     );
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,54 +1,15 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-import * as jose from 'jose';
-
-const protectedRoutes = ['/', '/dashboard', '/projects', '/tasks', '/team', '/clients', '/settings', '/workspaces', '/opportunities'];
-const publicRoutes = ['/login'];
-
-async function verifyToken(token: string, secret: Uint8Array) {
-  try {
-    await jose.jwtVerify(token, secret);
-    return true;
-  } catch (err) {
-    return false;
-  }
-}
-
-export async function middleware(request: NextRequest) {
-  const path = request.nextUrl.pathname;
-  const isProtectedRoute = protectedRoutes.includes(path) || path.startsWith('/project/') || path.startsWith('/workspace/');
-  const isPublicRoute = publicRoutes.includes(path);
-
-  const token = request.cookies.get('auth_token')?.value;
-  const secret = new TextEncoder().encode(process.env.JWT_SECRET!);
-
-  let isTokenValid = false;
-  if (token) {
-    isTokenValid = await verifyToken(token, secret);
-  }
-
-  if (isProtectedRoute && !isTokenValid) {
-    // Redirect to login and clear the invalid cookie if it exists
-    const response = NextResponse.redirect(new URL('/login', request.url));
-    if(token) response.cookies.delete('auth_token');
-    return response;
-  }
-
-  if (isPublicRoute && isTokenValid) {
-    // If user is logged in and tries to access login page, redirect to dashboard
-    return NextResponse.redirect(new URL('/', request.url));
-  }
-
-  return NextResponse.next();
-}
+export { default } from "next-auth/middleware"
 
 export const config = {
   matcher: [
-    // Match all request paths except for the ones starting with:
-    // - api (API routes)
-    // - _next/static (static files)
-    // - _next/image (image optimization files)
-    // - favicon.ico (favicon file)
-    '/((?!api|_next/static|_next/image|favicon.ico|avatars).*)',
-  ],
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - login (the login page)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico|login).*)',
+  ]
 };


### PR DESCRIPTION
This commit fixes a critical bug where the user was stuck on the login page after a successful authentication with either Google or credentials.

The root cause was twofold:
1.  The application's middleware was still using the old JWT verification logic, which is incompatible with NextAuth.js sessions.
2.  A race condition in the main AppLayout component caused it to redirect users back to the login page before the user's session data was fully loaded into the application's state.

The following changes were made to resolve this:
- Replaced the custom JWT middleware with the standard `next-auth/middleware`, configured to protect all necessary application routes.
- Refactored the `AppLayout` component to use the `useSession` hook from `next-auth/react` as the primary source of truth for authentication status. The layout now correctly waits for both the session to be established and for user data to be loaded before rendering, preventing the redirect loop.
- Removed the now-redundant `logout` handler from `AppLayout` as it is handled by the `UserNav` component.