### PR TITLE
fix: Restrict Google login and resolve participant creation bug

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,22 +1,33 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { useStore } from '@/hooks/use-store';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useToast } from '@/hooks/use-toast';
 import { signIn } from 'next-auth/react';
 import { Separator } from '@/components/ui/separator';
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { toast } = useToast();
   const [email, setEmail] = useState('admin@chb.com.br');
   const [password, setPassword] = useState('chb123');
   const [isLoading, setIsLoading] = useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
+
+  useEffect(() => {
+    const error = searchParams.get('error');
+    if (error === 'AccessDenied') {
+      toast({
+        variant: 'destructive',
+        title: 'Acesso Negado',
+        description: 'Seu email do Google não corresponde a nenhum usuário existente no sistema.',
+      });
+    }
+  }, [searchParams, toast]);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -100,7 +100,8 @@ export async function createParticipant(
     participant: Omit<Participant, 'id'> & { password?: string, googleId?: string }
 ): Promise<Participant> {
     const newId = `user_${randomBytes(8).toString('hex')}`;
-    const { name, email, password, roleId, avatar, provider, googleId } = participant;
+    // Default provider to 'local' if not specified. This fixes manual user creation from the UI.
+    const { name, email, password, roleId, avatar, provider = 'local', googleId } = participant;
 
     let passwordHash: string | null = null;
     if (provider === 'local' || password) {


### PR DESCRIPTION
This commit addresses two key issues:
1.  It restricts Google OAuth sign-in to only allow users whose email already exists in the `participants` table. This is enforced in the `signIn` callback of NextAuth.js. Users attempting to sign in with a new Google account are redirected to the login page with an error.
2.  It fixes a regression that prevented new participants from being created manually through the UI. The `createParticipant` database query has been updated to default the `provider` to 'local', ensuring the correct logic is applied for password hashing and data insertion.

Additionally, the login page has been updated to display a toast notification when a Google sign-in is denied, improving user feedback.